### PR TITLE
add project dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
     "type": "git",
     "url": "git://github.com/dominictarr/pull-goodbye.git"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "pull-stream": "~3.5.0"
+  },
+  "devDependencies": {
+    "muxrpc": "^2.1.0",
+    "pull-pushable": "^2.0.1",
+    "tape": "^4.6.3"
+  },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },


### PR DESCRIPTION
Otherwise this package cant even be tested. In strict package managers like pnpm, this is a problem since the lacking dependencies cause a runtime error.

Note that tests pass with `muxrpc@2.1.0` but *not* with the most recent muxrpc version. I don't know if this causes a silent a problem somewhere upstream in the ssb stack. Just wanted to mention it.